### PR TITLE
Subject line for SendGrid Activity screen

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,9 @@ By all means please contact me to discuss features or options you'd like to see 
 
 == Changelog ==
 
+= 0.10.2 =
+* SendGrid - adding email subject to the X-SMTPAPI header if the STMP host is on SendGrid, thanks to Foliovision
+
 = 0.10.1 =
 * Addition of Pepipost and cleanup of admin page.
 

--- a/wp_mail_smtp.php
+++ b/wp_mail_smtp.php
@@ -508,26 +508,26 @@ endif;
 /**
  * This function sets the SendGrid headers to be able to see subject on the Activity screen
  */
-if (!function_exists('wp_mail_smtp_mail_from_name')) :
+if (!function_exists('wp_mail_smtp_sendgrid_headers')) :
 function wp_mail_smtp_sendgrid_headers ($atts) {
 
-    $bIsSendGrid = false;
-    $sMailHost = get_option('smtp_host');
-    if (defined('WPMS_ON') && WPMS_ON && WPMS_SMTP_HOST ) {
-      $sMailHost = WPMS_SMTP_HOST;
-    }
-    if( stripos($sMailHost,'.sendgrid.') !== false ) $bIsSendGrid = true;
-  
-    if( $bIsSendGrid && isset($atts['subject']) ) {
-      $unique_args = json_encode( array( 'unique_args' => array( 'subject' => $atts['subject'] ) ) );
-      if( is_array($atts['headers']) ) {
-        $atts['headers'][] = 'X-SMTPAPI: '.$unique_args;
-      } else if( strlen($atts[3]) ) {
-        $atts['headers'] .= "\nX-SMTPAPI: ".$unique_args;
-      } else {
-        $atts['headers'] = "X-SMTPAPI: ".$unique_args;
-      }
-    }
+	$bIsSendGrid = false;
+	$sMailHost = get_option('smtp_host');
+	if (defined('WPMS_ON') && WPMS_ON && WPMS_SMTP_HOST ) {
+		$sMailHost = WPMS_SMTP_HOST;
+	}
+	if( stripos($sMailHost,'.sendgrid.') !== false ) $bIsSendGrid = true;
+	
+	if( $bIsSendGrid && isset($atts['subject']) ) {
+		$unique_args = json_encode( array( 'unique_args' => array( 'subject' => $atts['subject'] ) ) );
+		if( is_array($atts['headers']) ) {
+			$atts['headers'][] = 'X-SMTPAPI: '.$unique_args;
+		} else if( strlen($atts[3]) ) {
+			$atts['headers'] .= "\nX-SMTPAPI: ".$unique_args;
+		} else {
+			$atts['headers'] = "X-SMTPAPI: ".$unique_args;
+		}
+	}
 
 	return $atts;
 


### PR DESCRIPTION
Hello Callum,

as you might know the dedicated SMTP service SendGrid provides no details about what emails were sent on their Activity Screen (that's how the call the log screen).

We are contributing an improvement for your plugin which detects use of SendGrid and appends these email headers. I'm sure your SendGrid users (like we are) will be thrilled to see this new feature.

Thanks,
Martin